### PR TITLE
Unset original message collection if found in session.

### DIFF
--- a/src/app/code/community/VinaiKopp/JsMessages/Model/Observer.php
+++ b/src/app/code/community/VinaiKopp/JsMessages/Model/Observer.php
@@ -12,6 +12,8 @@ class VinaiKopp_JsMessages_Model_Observer
             return;
         }
 
+        $this->_clearOriginalMessageCollection();
+
         $this->_rewriteMessageBlock();
 
         $this->_rewriteMessageCollection();
@@ -58,6 +60,21 @@ class VinaiKopp_JsMessages_Model_Observer
         $collectionClassName = Mage::getConfig()->getModelClassName('vinaikopp_jsmessages/core_message_collection');
         if ($collectionClassName) {
             Mage::getConfig()->setNode('global/models/core/rewrite/message_collection', $collectionClassName);
+        }
+    }
+
+    /**
+     * Upon initial deployment ensure that old message collection
+     * that was serialised to session isn't used.
+     */
+    private function _clearOriginalMessageCollection()
+    {
+        foreach($this->getSessionMessageStorages() as $sessionType) {
+            $session = Mage::getSingleton($sessionType);
+            $messages = $session->getData('messages');
+            if (get_class($messages) == 'Mage_Core_Model_Message_Collection') {
+                $session->unsetData('messages');
+            }
         }
     }
 


### PR DESCRIPTION
The message collection is serialised to session storage. This means on initial deployment
of this extension, if sessions are not flushed a new message collection is not created
(and therefore our rewrite is never considered).  Rather than requiring a flushing of sessions
upon deployment, perform a check for the message collection being of the original type.

This means that it must have been retrieved from session or that the rewrite failed.
The rest of this code assumes that the rewrite is successful at this point.
